### PR TITLE
Pragmatic solution: copy test and package to push workflow that runs …

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,29 @@
+#started from: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+# This workflow will do a clean installation of node dependencies, cache/restore them,
+  #(not anymore: build the source code and run tests across different versions of node)
+# package the minified browser bundle under dist/src
+# and then push it to the web-editor: commit and push to main, this will trigger the deployment to that repository's GItHubPages automatically
+
+name: Push to WebEditor (except Publish)
+
+on:
+  push:
+    branches-ignore: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js 22.x
+      uses: actions/setup-node@v4
+      with:
+        node-version: 22.x
+        cache: 'npm'
+    - run: npm ci
+   # - run: npm run build --if-present
+    - run: npm run test:ci
+    - run: npm exec ng run keml.graphical:package
+    #now, minified version lies under dist/docs


### PR DESCRIPTION
…on every push EXCEPT master - this is just the first part of the publish. Should actually be done in one script but the syntax is complex