### PR TITLE
95 allow to export the whole view as png or jpg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "emfular": "^1.2.0",
         "express": "^4.18.2",
         "material-icons": "^1.13.12",
-        "ngx-emfular-helper": "^0.1.0",
+        "ngx-emfular-helper": "^0.2.0",
         "ngx-svg-graphics": "^1.1.0",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0",
@@ -10557,9 +10557,9 @@
       "license": "MIT"
     },
     "node_modules/ngx-emfular-helper": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-emfular-helper/-/ngx-emfular-helper-0.1.0.tgz",
-      "integrity": "sha512-zS5bafBA7gTZ98ag49DNFtNkXNCpQqPjW9amtuHdMchWBQp3YsM267DnU/NAi4yffrpGgBAnq+5lalXs8Fq7rg==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ngx-emfular-helper/-/ngx-emfular-helper-0.2.0.tgz",
+      "integrity": "sha512-gYarLW8j+0thcrk8ZttRX7gagUjlZAYSHxG4Y5Q+EUT1GeRPkoqyrEbngi3OrMZ6aJbVCHM5mlLjtJzELk+Ddg==",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "express": "^4.18.2",
     "material-icons": "^1.13.12",
     "ngx-svg-graphics": "^1.1.0",
-    "ngx-emfular-helper": "^0.1.0",
+    "ngx-emfular-helper": "^0.2.0",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.15.0"

--- a/src/app/features/editor/editor/editor.component.html
+++ b/src/app/features/editor/editor/editor.component.html
@@ -29,6 +29,10 @@
         <mat-icon aria-hidden="false" fontIcon="photo_library" ></mat-icon>
         Save PNG
       </button>
+      <button class="file-level-button" (click)="saveSVGasJPEG()">
+        <mat-icon aria-hidden="false" fontIcon="photo_library" ></mat-icon>
+        Save JPEG
+      </button>
       <button class="file-level-button" (click)="openSimulation()">
         <!--fontIcon="open_in_new" lightbulb_outline-->
         <mat-icon aria-hidden="false" fontIcon="schedule" ></mat-icon>

--- a/src/app/features/editor/editor/editor.component.ts
+++ b/src/app/features/editor/editor/editor.component.ts
@@ -54,6 +54,13 @@ export class EditorComponent {
     }
   }
 
+  saveSVGasJPEG() {
+    const svgContent = this.svg.nativeElement;
+    if(svgContent) {
+      this.ioService.saveSvgAsJpeg(svgContent, this.kemlService.conversation.title)
+    }
+  }
+
   openKeml() {
     document.getElementById('openKEML')?.click();
   }

--- a/src/app/features/simulator/simulator/simulator.component.html
+++ b/src/app/features/simulator/simulator/simulator.component.html
@@ -8,6 +8,10 @@
         <mat-icon aria-hidden="false" fontIcon="photo_library" ></mat-icon>
         Save PNG
     </button>
+    <button class="file-level-button" (click)="saveSVGasJPEG()">
+        <mat-icon aria-hidden="false" fontIcon="photo_library" ></mat-icon>
+        Save JPEG
+    </button>
   <button class="file-level-button" (click)="simulateIncrementally()" [disabled]="showIncremental" >
     <mat-icon aria-hidden="false" fontIcon="play_circle_outline" ></mat-icon>
     Simulate Incrementally

--- a/src/app/features/simulator/simulator/simulator.component.ts
+++ b/src/app/features/simulator/simulator/simulator.component.ts
@@ -103,4 +103,10 @@ export class SimulatorComponent implements OnInit {
     }
   }
 
+  saveSVGasJPEG() {
+    const svgContent = this.simulationSvg.nativeElement;
+    if(svgContent) {
+      this.ioService.saveSvgAsJpeg(svgContent, this.conversation.title)
+    }
+  }
 }


### PR DESCRIPTION
Closes #95 
We have been able to make the svg displayable and add both buttons for jpeg and png. Both methods are abstracted into ngx-emfular-helper 0.2.0 so that they are now generally available.